### PR TITLE
[고도화] 코드 최적화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,8 +59,8 @@ task cleanFrontEnd(type: Delete) {
 	delete "$projectDir/front-end/static", "$projectDir/front-end/node_modules"
 }
 
-//npmBuild.dependsOn npmInstall
-//copyFrontEnd.dependsOn npmBuild
-//compileJava.dependsOn copyFrontEnd
-//
-//clean.dependsOn cleanFrontEnd
+npmBuild.dependsOn npmInstall
+copyFrontEnd.dependsOn npmBuild
+compileJava.dependsOn copyFrontEnd
+
+clean.dependsOn cleanFrontEnd

--- a/src/main/java/com/fastcampus/sns/config/filter/JwtTokenFilter.java
+++ b/src/main/java/com/fastcampus/sns/config/filter/JwtTokenFilter.java
@@ -40,17 +40,14 @@ public class JwtTokenFilter extends OncePerRequestFilter {
         try {
             final String token = header.split(" ")[1].trim();
 
-            // TODO : check token is valid
             if (JwtTokenUtils.isExpired(token, key)) {
                 log.error("Key is expired!");
                 filterChain.doFilter(request, response);
                 return;
             }
 
-            // TODO : get username from token
             String userName = JwtTokenUtils.getUserName(token, key);
 
-            // TODO : check the user is valid
             User user = userService.loadUserByUsername(userName);
 
             UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(

--- a/src/main/java/com/fastcampus/sns/controller/PostController.java
+++ b/src/main/java/com/fastcampus/sns/controller/PostController.java
@@ -6,7 +6,6 @@ import com.fastcampus.sns.controller.request.PostModifyRequest;
 import com.fastcampus.sns.controller.response.CommentResponse;
 import com.fastcampus.sns.controller.response.PostResponse;
 import com.fastcampus.sns.controller.response.Response;
-import com.fastcampus.sns.model.Comment;
 import com.fastcampus.sns.model.Post;
 import com.fastcampus.sns.service.PostService;
 import lombok.RequiredArgsConstructor;
@@ -58,7 +57,7 @@ public class PostController {
     }
 
     @GetMapping("/{postId}/likes")
-    public Response<Integer> likeCount(@PathVariable("postId") Integer postId) {
+    public Response<Long> likeCount(@PathVariable("postId") Integer postId) {
         return Response.success(postService.likeCount(postId));
     }
 

--- a/src/main/java/com/fastcampus/sns/controller/UserController.java
+++ b/src/main/java/com/fastcampus/sns/controller/UserController.java
@@ -6,9 +6,12 @@ import com.fastcampus.sns.controller.response.AlarmResponse;
 import com.fastcampus.sns.controller.response.Response;
 import com.fastcampus.sns.controller.response.UserJoinResponse;
 import com.fastcampus.sns.controller.response.UserLoginResponse;
+import com.fastcampus.sns.exception.ErrorCode;
+import com.fastcampus.sns.exception.SnsApplicationException;
 import com.fastcampus.sns.model.Alarm;
 import com.fastcampus.sns.model.User;
 import com.fastcampus.sns.service.UserService;
+import com.fastcampus.sns.util.ClassUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -36,7 +39,11 @@ public class UserController {
 
     @GetMapping("/alarm")
     public Response<Page<AlarmResponse>> alarm(Authentication authentication, Pageable pageable) {
-        return Response.success(userService.alarmList(authentication.getName(), pageable).map(AlarmResponse::fromAlarm));
+
+        User user = ClassUtils.getSafeCastInstance(authentication.getPrincipal(), User.class)
+                .orElseThrow(() -> new SnsApplicationException(ErrorCode.INTERNAL_SERVER_ERROR, "Casting to User class failed!"));
+
+        return Response.success(userService.alarmList(user.getId(), pageable).map(AlarmResponse::fromAlarm));
     }
 
 

--- a/src/main/java/com/fastcampus/sns/model/Alarm.java
+++ b/src/main/java/com/fastcampus/sns/model/Alarm.java
@@ -1,17 +1,17 @@
 package com.fastcampus.sns.model;
 
 import com.fastcampus.sns.model.entity.AlarmEntity;
-import com.fastcampus.sns.model.entity.CommentEntity;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 
 import java.sql.Timestamp;
 
+@Slf4j
 @Getter
 @AllArgsConstructor
 public class Alarm {
     private Integer id;
-    private User user;
     private AlarmType alarmType;
     private AlarmArgs args;
     private Timestamp registeredAt;
@@ -21,7 +21,6 @@ public class Alarm {
     public static Alarm fromEntity(AlarmEntity entity) {
         return new Alarm(
                 entity.getId(),
-                User.fromEntity(entity.getUser()),
                 entity.getAlarmType(),
                 entity.getAlarmArgs(),
                 entity.getRegisteredAt(),

--- a/src/main/java/com/fastcampus/sns/model/entity/AlarmEntity.java
+++ b/src/main/java/com/fastcampus/sns/model/entity/AlarmEntity.java
@@ -32,7 +32,7 @@ public class AlarmEntity {
     private Integer id;
 
     // 알람을 받는 사람
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private UserEntity user;
 

--- a/src/main/java/com/fastcampus/sns/repository/AlarmEntityRepository.java
+++ b/src/main/java/com/fastcampus/sns/repository/AlarmEntityRepository.java
@@ -1,12 +1,11 @@
 package com.fastcampus.sns.repository;
 
 import com.fastcampus.sns.model.entity.AlarmEntity;
-import com.fastcampus.sns.model.entity.UserEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AlarmEntityRepository extends JpaRepository<AlarmEntity, Integer> {
 
-    Page<AlarmEntity> findAllByUser(UserEntity user, Pageable pageable);
+    Page<AlarmEntity> findAllByUserId(Integer userId, Pageable pageable);
 }

--- a/src/main/java/com/fastcampus/sns/repository/CommentEntityRepository.java
+++ b/src/main/java/com/fastcampus/sns/repository/CommentEntityRepository.java
@@ -7,8 +7,10 @@ import com.fastcampus.sns.model.entity.UserEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -16,4 +18,10 @@ import java.util.Optional;
 public interface CommentEntityRepository extends JpaRepository<CommentEntity, Integer> {
 
     Page<CommentEntity> findAllByPost(PostEntity post, Pageable pageable);
+
+    @Transactional
+    @Modifying
+    @Query("UPDATE CommentEntity entity SET entity.deletedAt = NOW() where entity.post = :post")
+    void deleteAllByPost(@Param("post") PostEntity postEntity);
+
 }

--- a/src/main/java/com/fastcampus/sns/repository/LikeEntityRepository.java
+++ b/src/main/java/com/fastcampus/sns/repository/LikeEntityRepository.java
@@ -6,8 +6,10 @@ import com.fastcampus.sns.model.entity.UserEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -16,7 +18,14 @@ public interface LikeEntityRepository extends JpaRepository<LikeEntity, Integer>
 
     Optional<LikeEntity> findByUserAndPost(UserEntity user, PostEntity post);
 
-    @Query("SELECT COUNT(*) FROM LikeEntity entity where entity.post = :post")
-    Integer countByPost(@Param("post") PostEntity post);
+//    @Query("SELECT COUNT(*) FROM LikeEntity entity where entity.post = :post")
+//    Integer countByPost(@Param("post") PostEntity post);
+
+    long countByPost(PostEntity post);
     List<LikeEntity> findAllByPost(PostEntity post);
+
+    @Transactional
+    @Modifying
+    @Query("UPDATE LikeEntity entity SET entity.deletedAt = NOW() where entity.post = :post")
+    void deleteAllByPost(@Param("post") PostEntity postEntity);
 }

--- a/src/main/java/com/fastcampus/sns/service/PostService.java
+++ b/src/main/java/com/fastcampus/sns/service/PostService.java
@@ -3,7 +3,6 @@ package com.fastcampus.sns.service;
 import com.fastcampus.sns.exception.ErrorCode;
 import com.fastcampus.sns.exception.SnsApplicationException;
 import com.fastcampus.sns.model.AlarmArgs;
-import com.fastcampus.sns.model.AlarmType;
 import com.fastcampus.sns.model.Comment;
 import com.fastcampus.sns.model.Post;
 import com.fastcampus.sns.model.entity.*;
@@ -13,8 +12,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 import static com.fastcampus.sns.model.AlarmType.NEW_COMMENT_ON_POST;
 import static com.fastcampus.sns.model.AlarmType.NEW_LIKE_ON_POST;
@@ -66,6 +63,8 @@ public class PostService {
             );
         }
 
+        likeEntityRepository.deleteAllByPost(postEntity);
+        commentEntityRepository.deleteAllByPost(postEntity);
         postEntityRepository.deleteById(postId);
     }
 
@@ -97,7 +96,7 @@ public class PostService {
 
     }
 
-    public int likeCount(Integer postId) {
+    public long likeCount(Integer postId) {
         PostEntity postEntity = getPostEntityOrException(postId);
 
         return likeEntityRepository.countByPost(postEntity);

--- a/src/main/java/com/fastcampus/sns/service/UserService.java
+++ b/src/main/java/com/fastcampus/sns/service/UserService.java
@@ -4,7 +4,6 @@ import com.fastcampus.sns.exception.ErrorCode;
 import com.fastcampus.sns.exception.SnsApplicationException;
 import com.fastcampus.sns.model.Alarm;
 import com.fastcampus.sns.model.User;
-import com.fastcampus.sns.model.entity.AlarmEntity;
 import com.fastcampus.sns.model.entity.UserEntity;
 import com.fastcampus.sns.repository.AlarmEntityRepository;
 import com.fastcampus.sns.repository.UserEntityRepository;
@@ -16,8 +15,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -68,12 +65,7 @@ public class UserService {
         return token;
     }
 
-    public Page<Alarm> alarmList(String userName, Pageable pageable) {
-        UserEntity userEntity = userEntityRepository.findByUserName(userName)
-                .orElseThrow(() -> new SnsApplicationException(ErrorCode.USER_NOT_FOUND, String.format("%s not founded!", userName)));
-
-        return alarmEntityRepository
-                .findAllByUser(userEntity, pageable)
-                .map(Alarm::fromEntity);
+    public Page<Alarm> alarmList(Integer userId, Pageable pageable) {
+        return alarmEntityRepository.findAllByUserId(userId, pageable).map(Alarm::fromEntity);
     }
 }

--- a/src/main/java/com/fastcampus/sns/util/ClassUtils.java
+++ b/src/main/java/com/fastcampus/sns/util/ClassUtils.java
@@ -1,0 +1,10 @@
+package com.fastcampus.sns.util;
+
+import java.util.Optional;
+
+public class ClassUtils {
+
+    public static <T> Optional<T> getSafeCastInstance(Object o, Class<T> clazz) {
+        return clazz != null && clazz.isInstance(o) ? Optional.of(clazz.cast(o)) : Optional.empty();
+    }
+}


### PR DESCRIPTION
중복되서 호출되던 쿼리문들을 줄이는 작업을 진행함
엔티티 삭제를 진행할 때 jpa에서 제공하는 메서드를 사용하기 보다는 
직접 쿼리를 작성해서 최적화한 쿼리를 통해 삭제하는 것이 효율적이다.
제공되는 메서드를 사용하는 경우에는 엔티티를 한 번 조회한 후에 삭제를 진행하기 때문에 N+1 문제가 발생함

This closes #11 